### PR TITLE
Working

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
-
+/* Test */
 test('renders learn react link', () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);

--- a/src/Result.js
+++ b/src/Result.js
@@ -45,9 +45,7 @@ export function Result({
     queryClient.invalidateQueries([
       keys.VIDEOS,
       video?._id,
-      "summarize",
-      "chapters",
-      "highlights",
+      "generate"
     ]);
   }, [field1Prompt?.type, field2Prompt?.type, field3Prompt?.type]);
 

--- a/src/SummarizeVideo.js
+++ b/src/SummarizeVideo.js
@@ -22,7 +22,7 @@ export function SummarizeVideo({ index, videoId, refetchVideos }) {
   const { data: video, isLoading } = useGetVideo(
     index,
     videoId,
-    Boolean(videoId)
+    
   );
 
   const [field1, field2, field3] = ["summary", "chapter", "highlight"];

--- a/src/apiHooks.js
+++ b/src/apiHooks.js
@@ -70,14 +70,14 @@ export async function fetchVideoInfo(queryClient, url) {
 
 export function useGenerateSummary(data, videoId, enabled) {
   return useQuery({
-    queryKey: [keys.VIDEOS, "summarize", videoId],
+    queryKey: [keys.VIDEOS, "generate", videoId],
     queryFn: async () => {
       if (!enabled) {
         return null;
       }
 
       const response = await apiConfig.SERVER.post(
-        `/videos/${videoId}/summarize`,
+        `/videos/${videoId}/generate`,
         { data }
       );
       const respData = response.data;
@@ -89,14 +89,14 @@ export function useGenerateSummary(data, videoId, enabled) {
 
 export function useGenerateChapters(data, videoId, enabled) {
   return useQuery({
-    queryKey: [keys.VIDEOS, "chapters", videoId],
+    queryKey: [keys.VIDEOS, "generate", videoId],
     queryFn: async () => {
       if (!enabled) {
         return null;
       }
 
       const response = await apiConfig.SERVER.post(
-        `/videos/${videoId}/summarize`,
+        `/videos/${videoId}/generate`,
         { data }
       );
       const respData = response.data;
@@ -108,14 +108,14 @@ export function useGenerateChapters(data, videoId, enabled) {
 
 export function useGenerateHighlights(data, videoId, enabled) {
   return useQuery({
-    queryKey: [keys.VIDEOS, "highlights", videoId],
+    queryKey: [keys.VIDEOS, "generate", videoId],
     queryFn: async () => {
       if (!enabled) {
         return null;
       }
 
       const response = await apiConfig.SERVER.post(
-        `/videos/${videoId}/summarize`,
+        `/videos/${videoId}/generate`,
         { data }
       );
       const respData = response.data;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
Unified API endpoint and query key structure for video processing features. Changed API endpoint from `/videos/{id}/summarize` to `/videos/{id}/generate` in API hooks and updated related query keys to use a consistent "generate" identifier instead of separate keys for different content types.


___

### **Sequence diagram**
```mermaid
sequenceDiagram
    participant Client as Client
    participant API as API Service
    participant Cache as Query Cache
    
    Client->>API: POST /videos/{id}/generate
    API-->>Client: Generated Content
    Client->>Cache: Store with [VIDEOS, "generate", videoId]
    Note over Client, Cache: Previously used separate keys:<br/>"summarize", "chapters", "highlights"
```



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.test.js</strong><dd><code>Add test comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.test.js

- Added a /* Test */ comment to the test file


</details>


  </td>
  <td><a href="https://github.com/crossbizz/tl-summarize-youtube-video/pull/49/files#diff-1270de3bbb227435f61afc0333dccf3e1bcde4a082bf31a61acf489ae9bb3200">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Result.js</strong><dd><code>Simplify query invalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Result.js

<li>Updated queryClient.invalidateQueries to use a single "generate" key <br>instead of separate keys for "summarize", "chapters", and "highlights"


</details>


  </td>
  <td><a href="https://github.com/crossbizz/tl-summarize-youtube-video/pull/49/files#diff-c65c1891786c0eb46a0e3743e86a511ca33c8daf16c43701e8b1dec93bf873a0">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SummarizeVideo.js</strong><dd><code>Remove Boolean conversion parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SummarizeVideo.js

- Removed Boolean(videoId) parameter from useGetVideo hook call


</details>


  </td>
  <td><a href="https://github.com/crossbizz/tl-summarize-youtube-video/pull/49/files#diff-06f876073b97b8741862017ab8982df8373e4ebcec6be0f2595bd8e387c73f46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>apiHooks.js</strong><dd><code>Unify API endpoints and query keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/apiHooks.js

<li>Changed queryKey from specific types ("summarize", "chapters", <br>"highlights") to unified "generate" key<br> <li> Updated API endpoints from <code>/videos/${videoId}/summarize</code> to <br><code>/videos/${videoId}/generate</code> in all three generator hooks


</details>


  </td>
  <td><a href="https://github.com/crossbizz/tl-summarize-youtube-video/pull/49/files#diff-e332f2951cf6f17fbfe2aeb1f2e9e6aa20c8716c20d08159c86ed45c850ad387">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about SonnetCode usage.</li><li>Check out the <a href="https://sonnetcode-docs.sonnetcode.ai/usage-guide/">documentation</a> for more information.</li></details>